### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/canardleteer/proptest-semver/compare/v0.1.1...v0.1.2) - 2025-03-07
+
+### Fixed
+
+- repo and homepage
+
+### Other
+
+- release fix
+- release v0.1.0
+
 ## [0.1.0](https://github.com/canardleteer/proptest-semver/releases/tag/v0.1.0) - 2025-03-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "proptest-semver"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "proptest-semver"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 exclude = []
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `proptest-semver`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/canardleteer/proptest-semver/compare/v0.1.1...v0.1.2) - 2025-03-07

### Fixed

- repo and homepage

### Other

- release fix
- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).