### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/canardleteer/proptest-semver/compare/v0.1.2...v0.1.3) - 2025-12-15
+
+### Other
+
+- *(deps)* bump actions/cache from 4 to 5
+- *(deps)* bump actions/checkout from 4 to 5
+
 ## [0.1.2](https://github.com/canardleteer/proptest-semver/compare/v0.1.1...v0.1.2) - 2025-03-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/canardleteer/proptest-semver/compare/v0.1.2...v0.1.3) - 2026-06-21
+
+### Fixed
+
+- less magic numbers
+- upgrade proptest and semver deps for rand advisory
+
+### Other
+
+- *(deps)* bump actions/checkout from 5 to 6
+- *(deps)* bump actions/cache from 4 to 5
+- *(deps)* bump actions/checkout from 4 to 5
+
 ## [0.1.2](https://github.com/canardleteer/proptest-semver/compare/v0.1.1...v0.1.2) - 2025-03-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "proptest-semver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proptest",
  "proptest-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "proptest-semver"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "proptest-semver"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 exclude = []
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `proptest-semver`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/canardleteer/proptest-semver/compare/v0.1.2...v0.1.3) - 2026-06-21

### Fixed

- less magic numbers
- upgrade proptest and semver deps for rand advisory

### Other

- *(deps)* bump actions/checkout from 5 to 6
- *(deps)* bump actions/cache from 4 to 5
- *(deps)* bump actions/checkout from 4 to 5
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).