### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/canardleteer/proptest-semver/compare/v0.1.3...v0.1.4) - 2026-06-30
+
+### Other
+
+- *(deps)* bump actions/cache from 5 to 6
+
 ## [0.1.3](https://github.com/canardleteer/proptest-semver/compare/v0.1.2...v0.1.3) - 2026-06-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "proptest-semver"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "proptest",
  "proptest-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@
 # limitations under the License.
 [package]
 name = "proptest-semver"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 exclude = []
 license = "Apache-2.0"


### PR DESCRIPTION



## 🤖 New release

* `proptest-semver`: 0.1.3 -> 0.1.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/canardleteer/proptest-semver/compare/v0.1.3...v0.1.4) - 2026-06-30

### Other

- *(deps)* bump actions/cache from 5 to 6
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).